### PR TITLE
chore: upgrade Go to 1.25.8 and update Dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM quay.io/zncdatadev/go-devel:1.25.5-kubedoop0.0.0-dev AS builder
+FROM quay.io/zncdatadev/go-devel:1.25.8-kubedoop0.0.0-dev AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zncdatadev/commons-operator
 
-go 1.25.5
+go 1.25.8
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
## Summary

- Update `go.mod` from `go 1.25.5` to `go 1.25.8`
- Update `Dockerfile` base image from `go-devel:1.25.5-kubedoop0.0.0-dev` to `go-devel:1.25.8-kubedoop0.0.0-dev`

## Motivation

Align with `docker-images` 0.4.0, which no longer builds the `go-devel:1.25.5` image. Available go-devel versions in docker-images 0.4.0 are: 1.26.0, 1.25.8, 1.24.13, 1.23.12.

## Testing

- `go mod tidy` — no changes needed
- Go 1.25.8 is backward compatible with 1.25.5