### PR TITLE
fix: update Chart.yaml version to 0.4.0 for release

### DIFF
--- a/deploy/helm/commons-operator/Chart.yaml
+++ b/deploy/helm/commons-operator/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.0-dev
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.0.0-dev
+appVersion: 0.4.0
 
 maintainers:
   - email: zncdatadev@googlegroups.com


### PR DESCRIPTION
## Summary

- Update Chart.yaml from version 0.0.0-dev to 0.4.0
- Update appVersion from 0.0.0-dev to 0.4.0

## Motivation

This fixes the chart-lint-test failure in the 0.4.0 release workflow. The chart version was hardcoded to dev version, which caused the chart linting to fail.

## Testing

- Chart.yaml now matches the release tag 0.4.0
- Chart linting should pass with this change