### PR TITLE
Release 0.4.0: Version bump and release preparation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,24 +220,35 @@ jobs:
       - name: Fetch all tags
         run: git fetch --tags --force
 
+      - name: Get commit range
+        id: commit-range
+        run: |
+          # Get current tag's commit
+          CURRENT_TAG="${{ github.ref_name }}"
+          CURRENT_COMMIT=$(git rev-list -n1 "$CURRENT_TAG")
+          echo "current_commit=$CURRENT_COMMIT" >> "$GITHUB_OUTPUT"
+
+          # Get previous tag if exists
+          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -v "^${CURRENT_TAG}$" | head -n1 || true)
+
+          if [[ -z "$PREVIOUS_TAG" ]]; then
+            # If this is the first tag, get the first commit
+            SINCE_COMMIT=$(git rev-list --max-parents=0 HEAD)
+            echo "First release - using first commit: $SINCE_COMMIT"
+          else
+            SINCE_COMMIT=$(git rev-list -n1 "$PREVIOUS_TAG")
+            echo "Using previous tag $PREVIOUS_TAG commit: $SINCE_COMMIT"
+          fi
+          echo "since_commit=$SINCE_COMMIT" >> "$GITHUB_OUTPUT"
+
       - name: Check chart changes
         id: check-changes
         run: |
-          # Get current and previous tag
-          CURRENT_TAG="${{ github.ref_name }}"
-          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -A1 "^${CURRENT_TAG}$" | tail -n1)
-
-          # First release detection
-          if [[ "$PREVIOUS_TAG" == "$CURRENT_TAG" || -z "$PREVIOUS_TAG" ]]; then
-            echo "First release detected - marking all charts as changed"
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "Comparing with previous tag: $PREVIOUS_TAG"
-
-          # Check for changes in chart directory
-          if ! changed=$(ct list-changed --chart-dirs deploy/helm --target-branch "$PREVIOUS_TAG"); then
+          # Check for changes in chart directory using both --since and --target-branch parameters
+          if ! changed=$(ct list-changed \
+            --chart-dirs deploy/helm \
+            --since "${{ steps.commit-range.outputs.since_commit }}" \
+            --target-branch "${{ github.ref }}"); then
             echo "Failed to check for changes"
             exit 1
           fi

--- a/deploy/helm/commons-operator/Chart.yaml
+++ b/deploy/helm/commons-operator/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.0-dev
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.0.0-dev
+appVersion: 0.4.0
 
 maintainers:
   - email: zncdatadev@googlegroups.com

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zncdatadev/commons-operator
 
-go 1.24.1
+go 1.25.8
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
This PR prepares the release-0.4.0 branch for the official 0.4.0 release.

Changes:
- Bump Go version to 1.25.8
- Update Chart.yaml version and appVersion to 0.4.0
- Sync with upstream release workflow improvements

This PR should be merged to trigger the official release process.