### PR TITLE
docs: add release guide

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,9 +248,9 @@ jobs:
       - name: Get commit range
         id: commit-range
         run: |
-          # Get current and previous tag
+          # Get current and previous tag (exclude -dev pre-release tags)
           CURRENT_TAG="${{ github.ref_name }}"
-          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -A1 "^${CURRENT_TAG}$" | tail -n1)
+          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -v '\-dev$' | grep -A1 "^${CURRENT_TAG}$" | tail -n1)
 
           # First release detection
           if [[ "$PREVIOUS_TAG" == "$CURRENT_TAG" || -z "$PREVIOUS_TAG" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,9 +248,17 @@ jobs:
       - name: Get commit range
         id: commit-range
         run: |
-          # Get current and previous tag (exclude -dev pre-release tags)
+          # Get current and previous tag
+          # Exclude -dev pre-release tags only when looking for the previous tag,
+          # not when matching the current tag itself
           CURRENT_TAG="${{ github.ref_name }}"
-          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -v '\-dev$' | grep -A1 "^${CURRENT_TAG}$" | tail -n1)
+          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -A1 "^${CURRENT_TAG}$" | tail -n1 | grep -v '\-dev$')
+
+          # If the -dev tag itself was the only match (no previous stable tag found),
+          # try again excluding -dev to find the actual previous stable release
+          if [[ -z "$PREVIOUS_TAG" ]]; then
+            PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -v '\-dev$' | grep -A1 "^${CURRENT_TAG}$" | tail -n1)
+          fi
 
           # First release detection
           if [[ "$PREVIOUS_TAG" == "$CURRENT_TAG" || -z "$PREVIOUS_TAG" ]]; then

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,139 @@
+# Release Guide
+
+This document describes the standard release process for commons-operator.
+
+## Overview
+
+The release process follows a branch-based workflow:
+
+- **Main branch** (`main`): The default development branch where new features and bug fixes are merged.
+- **Release branch** (`release-x.y`): A long-lived branch for a minor version series (e.g., `release-0.4`). Created from `main` and used to stabilize and release versions within that series.
+
+## Release Process
+
+### 1. Create Release Branch (if not exists)
+
+Create a release branch from the latest `main`:
+
+```bash
+git checkout main
+git pull --rebase upstream main
+git checkout -b release-0.x
+git push upstream release-0.x
+```
+
+### 2. Prepare Version Changes
+
+Create a local branch for version changes and update all relevant files:
+
+```bash
+git checkout main
+git pull --rebase upstream main
+git checkout -b bump/release-x.y.z
+```
+
+#### Files to Update
+
+| File | Field | Description |
+|------|-------|-------------|
+| `Makefile` | `VERSION` | Application version (e.g., `VERSION ?= 0.4.0`) |
+| `deploy/helm/commons-operator/Chart.yaml` | `version` | Helm chart version |
+| `deploy/helm/commons-operator/Chart.yaml` | `appVersion` | Helm chart app version |
+
+> **Tip:** You can refer to the previous version's changes on the release branch (e.g., `git diff v0.3.0..release-0.3`) to see exactly which files were modified.
+
+### 3. Submit and Merge PR
+
+Push the version change branch and create a Pull Request targeting the release branch:
+
+```bash
+git push origin bump/release-x.y.z
+```
+
+Create a PR from `bump/release-x.y.z` to `release-0.x`. Wait for CI to pass and code review before merging.
+
+### 4. Tag and Publish
+
+After the PR is merged, tag the release and push to trigger the automated release workflow:
+
+```bash
+git checkout release-0.x
+git pull --rebase upstream release-0.x
+git tag vx.y.z upstream/release-0.x
+git push upstream vx.y.z
+```
+
+This triggers the [Release workflow](.github/workflows/release.yml) which runs the following jobs:
+
+- **Markdown Lint** — Lints markdown files under `docs/` and `README.*.md`
+- **Golang Lint** — Runs golangci-lint
+- **Golang Test** — Runs unit tests
+- **E2E Test** — Runs end-to-end tests across multiple Kubernetes versions (1.33, 1.34, 1.35)
+- **Chainsaw Test** — Runs Chainsaw E2E tests across multiple Kubernetes versions
+- **Release Image** — Builds and pushes multi-arch Docker image to `quay.io/zncdatadev/commons-operator:<version>`, and signs the image with Cosign
+- **Chart Lint & Test** — Validates and tests the Helm chart
+- **Release Chart** — Publishes the Helm chart to `quay.io/kubedoopcharts/commons-operator:<version>` (OCI registry) and updates the [kubedoop-helm-charts](https://github.com/zncdatadev/kubedoop-helm-charts) index
+
+## Versioning Convention
+
+commons-operator follows [Semantic Versioning](https://semver.org/):
+
+- **Patch** (x.y.Z): Bug fixes, no API changes
+- **Minor** (x.Y.z): New features, backward-compatible API changes
+- **Major** (X.y.z): Breaking API changes
+
+## Example
+
+Here is an example of releasing version `0.4.0` on the `release-0.4` branch:
+
+```bash
+# Step 1: Create release branch (skip if already exists)
+git checkout main
+git pull --rebase upstream main
+git checkout -b release-0.4
+git push upstream release-0.4
+
+# Step 2: Prepare version changes
+git checkout main
+git pull --rebase upstream main
+git checkout -b bump/release-0.4.0
+
+# Update Makefile VERSION
+sed -i 's/VERSION ?= 0.0.0-dev/VERSION ?= 0.4.0/' Makefile
+
+# Update Chart.yaml
+sed -i 's/version: 0.0.0-dev/version: 0.4.0/' deploy/helm/commons-operator/Chart.yaml
+sed -i 's/appVersion: 0.0.0-dev/appVersion: 0.4.0/' deploy/helm/commons-operator/Chart.yaml
+
+git add -A
+git commit -m "release: 0.4.0"
+git push origin bump/release-0.4.0
+
+# Step 3: Create PR to release-0.4, review and merge
+
+# Step 4: Tag and publish
+git checkout release-0.4
+git pull --rebase upstream release-0.4
+git tag v0.4.0 upstream/release-0.4
+git push upstream v0.4.0
+```
+
+## Troubleshooting
+
+### Chart release failed
+
+If the `chart-lint-test` or `release-chart` job fails, check the workflow logs for details. Common issues include:
+
+- **CRDs out of sync**: Run `make manifests` and `make helm-crd-sync` to regenerate CRDs, then commit the changes.
+- **Chart YAML validation errors**: Ensure `Chart.yaml` has correct `version` and `appVersion` fields.
+- **Previous tag not found**: For the first release on a new release branch, the workflow automatically detects this and marks all charts as changed.
+
+### Force re-trigger a release
+
+If the release workflow fails and you need to re-trigger after fixing the issue, delete and re-create the tag:
+
+```bash
+git push upstream :refs/tags/vx.y.z
+git tag vx.y.z upstream/release-0.x
+git push upstream vx.y.z
+```

--- a/docs/release.md
+++ b/docs/release.md
@@ -11,7 +11,7 @@ The release process follows a branch-based workflow:
 
 ## Release Process
 
-### 1. Create Release Branch (if not exists)
+### 1. Create Release Branch (if it does not exist)
 
 Create a release branch from the latest `main`:
 
@@ -24,11 +24,11 @@ git push upstream release-0.x
 
 ### 2. Prepare Version Changes
 
-Create a local branch for version changes and update all relevant files:
+Create a local branch based on the release branch for version changes:
 
 ```bash
-git checkout main
-git pull --rebase upstream main
+git checkout release-0.x
+git pull --rebase upstream release-0.x
 git checkout -b bump/release-x.y.z
 ```
 
@@ -37,8 +37,10 @@ git checkout -b bump/release-x.y.z
 | File | Field | Description |
 |------|-------|-------------|
 | `Makefile` | `VERSION` | Application version (e.g., `VERSION ?= 0.4.0`) |
-| `deploy/helm/commons-operator/Chart.yaml` | `version` | Helm chart version |
-| `deploy/helm/commons-operator/Chart.yaml` | `appVersion` | Helm chart app version |
+| `deploy/helm/commons-operator/Chart.yaml` | `version` | Helm chart version (development placeholder, overridden during release packaging) |
+| `deploy/helm/commons-operator/Chart.yaml` | `appVersion` | Helm chart app version (development placeholder, overridden during release packaging) |
+
+> **Note:** The `version` and `appVersion` in `Chart.yaml` serve as development-time defaults on `main`. During the release, the [`Makefile`](../Makefile) `helm-chart-package` target overrides both values using `--version $(VERSION) --app-version $(VERSION)`, where `VERSION` is derived from the Git tag name in the [Release workflow](../.github/workflows/release.yml). Updating `Chart.yaml` is still recommended so that the values on the release branch reflect the released version.
 
 > **Tip:** You can refer to the previous version's changes on the release branch (e.g., `git diff v0.3.0..release-0.3`) to see exactly which files were modified.
 
@@ -63,7 +65,7 @@ git tag vx.y.z upstream/release-0.x
 git push upstream vx.y.z
 ```
 
-This triggers the [Release workflow](.github/workflows/release.yml) which runs the following jobs:
+This triggers the [Release workflow](../.github/workflows/release.yml) which runs the following jobs:
 
 - **Markdown Lint** — Lints markdown files under `docs/` and `README.*.md`
 - **Golang Lint** — Runs golangci-lint
@@ -87,21 +89,21 @@ commons-operator follows [Semantic Versioning](https://semver.org/):
 Here is an example of releasing version `0.4.0` on the `release-0.4` branch:
 
 ```bash
-# Step 1: Create release branch (skip if already exists)
+# Step 1: Create release branch (skip if it does not exist)
 git checkout main
 git pull --rebase upstream main
 git checkout -b release-0.4
 git push upstream release-0.4
 
-# Step 2: Prepare version changes
-git checkout main
-git pull --rebase upstream main
+# Step 2: Prepare version changes (from the release branch, not main)
+git checkout release-0.4
+git pull --rebase upstream release-0.4
 git checkout -b bump/release-0.4.0
 
 # Update Makefile VERSION
 sed -i 's/VERSION ?= 0.0.0-dev/VERSION ?= 0.4.0/' Makefile
 
-# Update Chart.yaml
+# Update Chart.yaml (recommended for consistency on the release branch)
 sed -i 's/version: 0.0.0-dev/version: 0.4.0/' deploy/helm/commons-operator/Chart.yaml
 sed -i 's/appVersion: 0.0.0-dev/appVersion: 0.4.0/' deploy/helm/commons-operator/Chart.yaml
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -24,13 +24,23 @@ The `VERSION` in `Makefile` and `version`/`appVersion` in `Chart.yaml` are devel
 
 ### 1. Create Release Branch (if it does not exist)
 
-Create a release branch from the latest `main`:
+Create a release branch from the latest `main` on the upstream repository to avoid local code being out of sync.
+
+**Via GitHub WebUI:** Navigate to the repository page, click "Branch" → "New branch", name it `release-0.x` and base it on `main`.
+
+**Via GitHub API / gh CLI:**
 
 ```bash
-git checkout main
-git pull --rebase upstream main
-git checkout -b release-0.x
-git push upstream release-0.x
+git api repos/zncdatadev/commons-operator/git/refs \
+  -f ref=refs/heads/release-0.x \
+  -f sha=$(gh api repos/zncdatadev/commons-operator/git/ref/heads/main --jq .object.sha)
+```
+
+Then sync locally:
+
+```bash
+git fetch upstream
+git checkout release-0.x
 ```
 
 ### 2. Merge Stabilization Changes

--- a/docs/release.md
+++ b/docs/release.md
@@ -7,31 +7,45 @@ This document describes the standard release process for commons-operator.
 The release process follows a branch-based workflow:
 
 - **Main branch** (`main`): The default development branch where new features and bug fixes are merged.
-- **Release branch** (`release-x.y`): A long-lived branch for a minor version series (e.g., `release-0.4`). Created from `main`, only accepts bug fixes and dependency upgrades, no new features. All release tags are created from this branch to ensure published code is stable and verified.
+- **Release branch** (`release-x.y`): A long-lived branch for a minor version series
+  (e.g., `release-0.4`). Created from `main`, only accepts bug fixes and
+  dependency upgrades, no new features. All release tags are created from this
+  branch to ensure published code is stable and verified.
 
 ## How Versioning Works
 
-The release workflow does **not** require manual version changes in source files. The Git tag name serves as the single source of truth for the version number:
+The release workflow does **not** require manual version changes in source
+files. The Git tag name serves as the single source of truth for the version
+number:
 
-1. When a tag (e.g., `0.4.0`) is pushed, the [Release workflow](../.github/workflows/release.yml) sets `VERSION` from `github.ref_name`
-2. **Docker image** — uses `VERSION` directly: `quay.io/zncdatadev/commons-operator:<version>`
-3. **Helm chart** — `helm package --version $(VERSION) --app-version $(VERSION)` overrides the values in `Chart.yaml` during packaging
-4. **Helm chart publish** — pushes to `quay.io/kubedoopcharts/commons-operator:<version>` (OCI registry)
+1. When a tag (e.g., `0.4.0`) is pushed, the
+   [Release workflow](../.github/workflows/release.yml) sets `VERSION` from
+   `github.ref_name`
+2. **Docker image** — uses `VERSION` directly:
+   `quay.io/zncdatadev/commons-operator:<version>`
+3. **Helm chart** — `helm package --version $(VERSION) --app-version $(VERSION)`
+   overrides the values in `Chart.yaml` during packaging
+4. **Helm chart publish** — pushes to
+   `quay.io/kubedoopcharts/commons-operator:<version>` (OCI registry)
 
-The `VERSION` in `Makefile` and `version`/`appVersion` in `Chart.yaml` are development-time defaults (`0.0.0-dev`) on `main`. They do not need to be updated for a release.
+The `VERSION` in `Makefile` and `version`/`appVersion` in `Chart.yaml` are
+development-time defaults (`0.0.0-dev`) on `main`. They do not need to be
+updated for a release.
 
 ## Release Process
 
 ### 1. Create Release Branch (if it does not exist)
 
-Create a release branch from the latest `main` on the upstream repository to avoid local code being out of sync.
+Create a release branch from the latest `main` on the upstream repository to
+avoid local code being out of sync.
 
-**Via GitHub WebUI:** Navigate to the repository page, click "Branch" → "New branch", name it `release-0.x` and base it on `main`.
+**Via GitHub WebUI:** Navigate to the repository page, click "Branch" →
+"New branch", name it `release-0.x` and base it on `main`.
 
 **Via GitHub API / gh CLI:**
 
 ```bash
-git api repos/zncdatadev/commons-operator/git/refs \
+gh api repos/zncdatadev/commons-operator/git/refs \
   -f ref=refs/heads/release-0.x \
   -f sha=$(gh api repos/zncdatadev/commons-operator/git/ref/heads/main --jq .object.sha)
 ```
@@ -45,11 +59,14 @@ git checkout release-0.x
 
 ### 2. Merge Stabilization Changes
 
-Merge bug fixes, dependency upgrades, or other stabilization changes into the release branch via Pull Request from `main` or dedicated fix branches. Wait for CI to pass and code review before merging.
+Merge bug fixes, dependency upgrades, or other stabilization changes into the
+release branch via Pull Request from `main` or dedicated fix branches. Wait for
+CI to pass and code review before merging.
 
 ### 3. Tag and Publish
 
-When ready to release, tag the latest commit on the release branch and push to trigger the automated release workflow:
+When ready to release, tag the latest commit on the release branch and push to
+trigger the automated release workflow:
 
 ```bash
 git checkout release-0.x
@@ -58,16 +75,23 @@ git tag x.y.z upstream/release-0.x
 git push upstream x.y.z
 ```
 
-This triggers the [Release workflow](../.github/workflows/release.yml) which runs the following jobs:
+This triggers the [Release workflow](../.github/workflows/release.yml) which
+runs the following jobs:
 
 - **Markdown Lint** — Lints markdown files under `docs/` and `README.*.md`
 - **Golang Lint** — Runs golangci-lint
 - **Golang Test** — Runs unit tests
-- **E2E Test** — Runs end-to-end tests across multiple Kubernetes versions (1.33, 1.34, 1.35)
+- **E2E Test** — Runs end-to-end tests across multiple Kubernetes versions
+  (1.33, 1.34, 1.35)
 - **Chainsaw Test** — Runs Chainsaw E2E tests across multiple Kubernetes versions
-- **Release Image** — Builds and pushes multi-arch Docker image to `quay.io/zncdatadev/commons-operator:<version>`, and signs the image with Cosign
+- **Release Image** — Builds and pushes multi-arch Docker image to
+  `quay.io/zncdatadev/commons-operator:<version>`, and signs the image with
+  Cosign
 - **Chart Lint & Test** — Validates and tests the Helm chart
-- **Release Chart** — Publishes the Helm chart to `quay.io/kubedoopcharts/commons-operator:<version>` (OCI registry) and updates the [kubedoop-helm-charts](https://github.com/zncdatadev/kubedoop-helm-charts) index
+- **Release Chart** — Publishes the Helm chart to
+  `quay.io/kubedoopcharts/commons-operator:<version>` (OCI registry) and
+  updates the [kubedoop-helm-charts](https://github.com/zncdatadev/kubedoop-helm-charts)
+  index
 
 ## Versioning Convention
 
@@ -82,16 +106,19 @@ commons-operator follows [Semantic Versioning](https://semver.org/):
 Here is an example of releasing version `0.4.0` on the `release-0.4` branch:
 
 ```bash
-# Step 1: Create release branch (skip if it does not exist)
-git checkout main
-git pull --rebase upstream main
-git checkout -b release-0.4
-git push upstream release-0.4
+# Step 1: Create release branch on upstream (skip if it does not exist)
+# Via WebUI or:
+gh api repos/zncdatadev/commons-operator/git/refs \
+  -f ref=refs/heads/release-0.4 \
+  -f sha=$(gh api repos/zncdatadev/commons-operator/git/ref/heads/main --jq .object.sha)
+
+# Sync locally
+git fetch upstream
+git checkout release-0.4
 
 # Step 2: Merge stabilization changes via PR (skip if release branch is ready)
 
 # Step 3: Tag and publish
-git checkout release-0.4
 git pull --rebase upstream release-0.4
 git tag 0.4.0 upstream/release-0.4
 git push upstream 0.4.0
@@ -101,16 +128,21 @@ git push upstream 0.4.0
 
 ### Chart release failed
 
-If the `chart-lint-test` or `release-chart` job fails, check the workflow logs for details. Common issues include:
+If the `chart-lint-test` or `release-chart` job fails, check the workflow logs
+for details. Common issues include:
 
-- **CRDs out of sync**: Run `make manifests` and `make helm-crd-sync` to regenerate CRDs, then commit the changes.
-- **Previous tag not found**: For the first release on a new release branch, the workflow automatically detects this and marks all charts as changed.
+- **CRDs out of sync**: Run `make manifests` and `make helm-crd-sync` to
+  regenerate CRDs, then commit the changes.
+- **Previous tag not found**: For the first release on a new release branch, the
+  workflow automatically detects this and marks all charts as changed.
 
 ### Force re-trigger a release
 
-If the release workflow fails and you need to re-trigger after fixing the issue, delete and re-create the tag:
+If the release workflow fails and you need to re-trigger after fixing the
+issue, delete both the local and remote tag, then re-create and push:
 
 ```bash
+git tag -d x.y.z
 git push upstream :refs/tags/x.y.z
 git tag x.y.z upstream/release-0.x
 git push upstream x.y.z

--- a/docs/release.md
+++ b/docs/release.md
@@ -112,10 +112,12 @@ runs the following jobs:
 - **E2E Test** — Runs end-to-end tests across multiple Kubernetes versions
   (1.33, 1.34, 1.35)
 - **Chainsaw Test** — Runs Chainsaw E2E tests across multiple Kubernetes versions
+- **CRD Sync Check** — Verifies CRDs are in sync with manifests
+- **Chart Linter (Artifact Hub)** — Validates Helm chart metadata
+- **Chart Lint & Test** — Validates and tests the Helm chart
 - **Release Image** — Builds and pushes multi-arch Docker image to
   `quay.io/zncdatadev/commons-operator:<version>`, and signs the image with
   Cosign
-- **Chart Lint & Test** — Validates and tests the Helm chart
 - **Release Chart** — Publishes the Helm chart to
   `quay.io/kubedoopcharts/commons-operator:<version>` (OCI registry) and
   updates the [kubedoop-helm-charts](https://github.com/zncdatadev/kubedoop-helm-charts)
@@ -153,7 +155,8 @@ git tag 0.4.0-dev upstream/release-0.4
 git push upstream 0.4.0-dev
 # Wait for workflow to pass
 
-# Step 4: Tag and publish (stable version, can only be published once)git pull --rebase upstream release-0.4
+# Step 4: Tag and publish (stable version, can only be published once)
+git pull --rebase upstream release-0.4
 git tag 0.4.0 upstream/release-0.4
 git push upstream 0.4.0
 ```

--- a/docs/release.md
+++ b/docs/release.md
@@ -41,38 +41,16 @@ includes merging bug fixes, dependency upgrades, or other stabilization changes
 into `main` via Pull Request. Wait for CI to pass and code review before
 proceeding.
 
-### 2. Create Release Branch (if it does not exist)
+### 2. Pre-release Verification
 
-Create a release branch from the latest `main` on the upstream repository to
-avoid local code being out of sync.
-
-**Via GitHub WebUI:** Navigate to the repository page, click "Branch" →
-"New branch", name it `release-0.x` and base it on `main`.
-
-**Via GitHub API / gh CLI:**
+Before creating the release branch, push a `-dev` suffixed tag on `main` to
+verify the release workflow. This confirms the code can be released correctly
+without needing a release branch.
 
 ```bash
-gh api repos/zncdatadev/commons-operator/git/refs \
-  -f ref=refs/heads/release-0.x \
-  -f sha=$(gh api repos/zncdatadev/commons-operator/git/ref/heads/main --jq .object.sha)
-```
-
-Then sync locally:
-
-```bash
-git fetch upstream
-git checkout release-0.x
-```
-
-### 3. Pre-release Verification
-
-Before publishing a stable version, push a `-dev` suffixed tag to verify the
-release workflow. This allows you to catch and fix issues without affecting the
-official version. The `-dev` tag can be deleted and re-created if needed.
-
-```bash
-git pull --rebase upstream release-0.x
-git tag x.y.z-dev upstream/release-0.x
+git checkout main
+git pull --rebase upstream main
+git tag x.y.z-dev upstream/main
 git push upstream x.y.z-dev
 ```
 
@@ -93,8 +71,31 @@ git tag x.y.z-dev upstream/release-0.x
 git push upstream x.y.z-dev
 ```
 
-Once verified, you can proceed to publish the stable version directly.
-There is no need to clean up the `-dev` tag.
+Once verified, you can proceed to create the release branch and publish the
+stable version directly. There is no need to clean up the `-dev` tag.
+
+### 3. Create Release Branch
+
+Create a release branch on the upstream repository from the same commit that
+was verified by the pre-release.
+
+**Via GitHub WebUI:** Navigate to the repository page, click "Branch" →
+"New branch", name it `release-0.x` and base it on `main`.
+
+**Via GitHub API / gh CLI:**
+
+```bash
+gh api repos/zncdatadev/commons-operator/git/refs \
+  -f ref=refs/heads/release-0.x \
+  -f sha=$(gh api repos/zncdatadev/commons-operator/git/ref/heads/main --jq .object.sha)
+```
+
+Then sync locally:
+
+```bash
+git fetch upstream
+git checkout release-0.x
+```
 
 ### 4. Tag and Publish
 
@@ -138,23 +139,16 @@ Here is an example of releasing version `0.4.0` on the `release-0.4` branch:
 # Step 1: Prepare content on main
 # Merge stabilization changes via PR, wait for CI and review
 
-# Step 2: Create release branch on upstream (skip if it does not exist)
-# Via WebUI or:
-gh api repos/zncdatadev/commons-operator/git/refs \
-  -f ref=refs/heads/release-0.4 \
-  -f sha=$(gh api repos/zncdatadev/commons-operator/git/ref/heads/main --jq .object.sha)
-
-# Sync locally
-git fetch upstream
-git checkout release-0.4
-
-# Step 2: Merge stabilization changes via PR (skip if content is ready)
-
-# Step 3: Pre-release verification
-git pull --rebase upstream release-0.4
-git tag 0.4.0-dev upstream/release-0.4
+# Step 2: Pre-release verification
+git checkout main
+git pull --rebase upstream main
+git tag 0.4.0-dev upstream/main
 git push upstream 0.4.0-dev
 # Wait for workflow to pass
+
+# Step 3: Create release branch on upstream
+git fetch upstream
+git checkout release-0.4
 
 # Step 4: Tag and publish (stable version, can only be published once)git pull --rebase upstream release-0.4
 git tag 0.4.0 upstream/release-0.4

--- a/docs/release.md
+++ b/docs/release.md
@@ -34,7 +34,14 @@ updated for a release.
 
 ## Release Process
 
-### 1. Create Release Branch (if it does not exist)
+### 1. Prepare Content
+
+Prepare the code to be released before creating the release branch. This
+includes merging bug fixes, dependency upgrades, or other stabilization changes
+into `main` via Pull Request. Wait for CI to pass and code review before
+proceeding.
+
+### 2. Create Release Branch (if it does not exist)
 
 Create a release branch from the latest `main` on the upstream repository to
 avoid local code being out of sync.
@@ -56,12 +63,6 @@ Then sync locally:
 git fetch upstream
 git checkout release-0.x
 ```
-
-### 2. Merge Stabilization Changes
-
-Merge bug fixes, dependency upgrades, or other stabilization changes into the
-release branch via Pull Request from `main` or dedicated fix branches. Wait for
-CI to pass and code review before merging.
 
 ### 3. Pre-release Verification
 
@@ -96,9 +97,6 @@ Once verified, you can proceed to publish the stable version directly.
 There is no need to clean up the `-dev` tag.
 
 ### 4. Tag and Publish
-
-After the pre-release passes, publish the stable version. The stable tag can
-only be published once — re-tagging is **not allowed**.
 
 ```bash
 git pull --rebase upstream release-0.x
@@ -137,7 +135,10 @@ commons-operator follows [Semantic Versioning](https://semver.org/):
 Here is an example of releasing version `0.4.0` on the `release-0.4` branch:
 
 ```bash
-# Step 1: Create release branch on upstream (skip if it does not exist)
+# Step 1: Prepare content on main
+# Merge stabilization changes via PR, wait for CI and review
+
+# Step 2: Create release branch on upstream (skip if it does not exist)
 # Via WebUI or:
 gh api repos/zncdatadev/commons-operator/git/refs \
   -f ref=refs/heads/release-0.4 \
@@ -147,7 +148,7 @@ gh api repos/zncdatadev/commons-operator/git/refs \
 git fetch upstream
 git checkout release-0.4
 
-# Step 2: Merge stabilization changes via PR (skip if release branch is ready)
+# Step 2: Merge stabilization changes via PR (skip if content is ready)
 
 # Step 3: Pre-release verification
 git pull --rebase upstream release-0.4
@@ -155,8 +156,7 @@ git tag 0.4.0-dev upstream/release-0.4
 git push upstream 0.4.0-dev
 # Wait for workflow to pass
 
-# Step 4: Tag and publish (stable version, can only be published once)
-git pull --rebase upstream release-0.4
+# Step 4: Tag and publish (stable version, can only be published once)git pull --rebase upstream release-0.4
 git tag 0.4.0 upstream/release-0.4
 git push upstream 0.4.0
 ```

--- a/docs/release.md
+++ b/docs/release.md
@@ -75,6 +75,7 @@ git push upstream x.y.z-dev
 ```
 
 Wait for the release workflow to complete. Verify:
+
 - All jobs pass successfully
 - Docker image is available at
   `quay.io/zncdatadev/commons-operator:x.y.z-dev`

--- a/docs/release.md
+++ b/docs/release.md
@@ -7,7 +7,18 @@ This document describes the standard release process for commons-operator.
 The release process follows a branch-based workflow:
 
 - **Main branch** (`main`): The default development branch where new features and bug fixes are merged.
-- **Release branch** (`release-x.y`): A long-lived branch for a minor version series (e.g., `release-0.4`). Created from `main` and used to stabilize and release versions within that series.
+- **Release branch** (`release-x.y`): A long-lived branch for a minor version series (e.g., `release-0.4`). Created from `main`, only accepts bug fixes and dependency upgrades, no new features. All release tags are created from this branch to ensure published code is stable and verified.
+
+## How Versioning Works
+
+The release workflow does **not** require manual version changes in source files. The Git tag name serves as the single source of truth for the version number:
+
+1. When a tag (e.g., `0.4.0`) is pushed, the [Release workflow](../.github/workflows/release.yml) sets `VERSION` from `github.ref_name`
+2. **Docker image** — uses `VERSION` directly: `quay.io/zncdatadev/commons-operator:<version>`
+3. **Helm chart** — `helm package --version $(VERSION) --app-version $(VERSION)` overrides the values in `Chart.yaml` during packaging
+4. **Helm chart publish** — pushes to `quay.io/kubedoopcharts/commons-operator:<version>` (OCI registry)
+
+The `VERSION` in `Makefile` and `version`/`appVersion` in `Chart.yaml` are development-time defaults (`0.0.0-dev`) on `main`. They do not need to be updated for a release.
 
 ## Release Process
 
@@ -22,47 +33,19 @@ git checkout -b release-0.x
 git push upstream release-0.x
 ```
 
-### 2. Prepare Version Changes
+### 2. Merge Stabilization Changes
 
-Create a local branch based on the release branch for version changes:
+Merge bug fixes, dependency upgrades, or other stabilization changes into the release branch via Pull Request from `main` or dedicated fix branches. Wait for CI to pass and code review before merging.
 
-```bash
-git checkout release-0.x
-git pull --rebase upstream release-0.x
-git checkout -b bump/release-x.y.z
-```
+### 3. Tag and Publish
 
-#### Files to Update
-
-| File | Field | Description |
-|------|-------|-------------|
-| `Makefile` | `VERSION` | Application version (e.g., `VERSION ?= 0.4.0`) |
-| `deploy/helm/commons-operator/Chart.yaml` | `version` | Helm chart version (development placeholder, overridden during release packaging) |
-| `deploy/helm/commons-operator/Chart.yaml` | `appVersion` | Helm chart app version (development placeholder, overridden during release packaging) |
-
-> **Note:** The `version` and `appVersion` in `Chart.yaml` serve as development-time defaults on `main`. During the release, the [`Makefile`](../Makefile) `helm-chart-package` target overrides both values using `--version $(VERSION) --app-version $(VERSION)`, where `VERSION` is derived from the Git tag name in the [Release workflow](../.github/workflows/release.yml). Updating `Chart.yaml` is still recommended so that the values on the release branch reflect the released version.
-
-> **Tip:** You can refer to the previous version's changes on the release branch (e.g., `git diff v0.3.0..release-0.3`) to see exactly which files were modified.
-
-### 3. Submit and Merge PR
-
-Push the version change branch and create a Pull Request targeting the release branch:
-
-```bash
-git push origin bump/release-x.y.z
-```
-
-Create a PR from `bump/release-x.y.z` to `release-0.x`. Wait for CI to pass and code review before merging.
-
-### 4. Tag and Publish
-
-After the PR is merged, tag the release and push to trigger the automated release workflow:
+When ready to release, tag the latest commit on the release branch and push to trigger the automated release workflow:
 
 ```bash
 git checkout release-0.x
 git pull --rebase upstream release-0.x
-git tag vx.y.z upstream/release-0.x
-git push upstream vx.y.z
+git tag x.y.z upstream/release-0.x
+git push upstream x.y.z
 ```
 
 This triggers the [Release workflow](../.github/workflows/release.yml) which runs the following jobs:
@@ -95,29 +78,13 @@ git pull --rebase upstream main
 git checkout -b release-0.4
 git push upstream release-0.4
 
-# Step 2: Prepare version changes (from the release branch, not main)
+# Step 2: Merge stabilization changes via PR (skip if release branch is ready)
+
+# Step 3: Tag and publish
 git checkout release-0.4
 git pull --rebase upstream release-0.4
-git checkout -b bump/release-0.4.0
-
-# Update Makefile VERSION
-sed -i 's/VERSION ?= 0.0.0-dev/VERSION ?= 0.4.0/' Makefile
-
-# Update Chart.yaml (recommended for consistency on the release branch)
-sed -i 's/version: 0.0.0-dev/version: 0.4.0/' deploy/helm/commons-operator/Chart.yaml
-sed -i 's/appVersion: 0.0.0-dev/appVersion: 0.4.0/' deploy/helm/commons-operator/Chart.yaml
-
-git add -A
-git commit -m "release: 0.4.0"
-git push origin bump/release-0.4.0
-
-# Step 3: Create PR to release-0.4, review and merge
-
-# Step 4: Tag and publish
-git checkout release-0.4
-git pull --rebase upstream release-0.4
-git tag v0.4.0 upstream/release-0.4
-git push upstream v0.4.0
+git tag 0.4.0 upstream/release-0.4
+git push upstream 0.4.0
 ```
 
 ## Troubleshooting
@@ -127,7 +94,6 @@ git push upstream v0.4.0
 If the `chart-lint-test` or `release-chart` job fails, check the workflow logs for details. Common issues include:
 
 - **CRDs out of sync**: Run `make manifests` and `make helm-crd-sync` to regenerate CRDs, then commit the changes.
-- **Chart YAML validation errors**: Ensure `Chart.yaml` has correct `version` and `appVersion` fields.
 - **Previous tag not found**: For the first release on a new release branch, the workflow automatically detects this and marks all charts as changed.
 
 ### Force re-trigger a release
@@ -135,7 +101,7 @@ If the `chart-lint-test` or `release-chart` job fails, check the workflow logs f
 If the release workflow fails and you need to re-trigger after fixing the issue, delete and re-create the tag:
 
 ```bash
-git push upstream :refs/tags/vx.y.z
-git tag vx.y.z upstream/release-0.x
-git push upstream vx.y.z
+git push upstream :refs/tags/x.y.z
+git tag x.y.z upstream/release-0.x
+git push upstream x.y.z
 ```

--- a/docs/release.md
+++ b/docs/release.md
@@ -92,12 +92,8 @@ git tag x.y.z-dev upstream/release-0.x
 git push upstream x.y.z-dev
 ```
 
-Once verified, clean up the `-dev` tag:
-
-```bash
-git tag -d x.y.z-dev
-git push upstream :refs/tags/x.y.z-dev
-```
+Once verified, you can proceed to publish the stable version directly.
+There is no need to clean up the `-dev` tag.
 
 ### 4. Tag and Publish
 
@@ -157,9 +153,7 @@ git checkout release-0.4
 git pull --rebase upstream release-0.4
 git tag 0.4.0-dev upstream/release-0.4
 git push upstream 0.4.0-dev
-# Wait for workflow to pass, then clean up
-git tag -d 0.4.0-dev
-git push upstream :refs/tags/0.4.0-dev
+# Wait for workflow to pass
 
 # Step 4: Tag and publish (stable version, can only be published once)
 git pull --rebase upstream release-0.4

--- a/docs/release.md
+++ b/docs/release.md
@@ -63,13 +63,48 @@ Merge bug fixes, dependency upgrades, or other stabilization changes into the
 release branch via Pull Request from `main` or dedicated fix branches. Wait for
 CI to pass and code review before merging.
 
-### 3. Tag and Publish
+### 3. Pre-release Verification
 
-When ready to release, tag the latest commit on the release branch and push to
-trigger the automated release workflow:
+Before publishing a stable version, push a `-dev` suffixed tag to verify the
+release workflow. This allows you to catch and fix issues without affecting the
+official version. The `-dev` tag can be deleted and re-created if needed.
 
 ```bash
-git checkout release-0.x
+git pull --rebase upstream release-0.x
+git tag x.y.z-dev upstream/release-0.x
+git push upstream x.y.z-dev
+```
+
+Wait for the release workflow to complete. Verify:
+- All jobs pass successfully
+- Docker image is available at
+  `quay.io/zncdatadev/commons-operator:x.y.z-dev`
+- Helm chart is available at
+  `quay.io/kubedoopcharts/commons-operator:x.y.z-dev`
+
+If the workflow fails, fix the issue, then delete and re-create the `-dev`
+tag:
+
+```bash
+git tag -d x.y.z-dev
+git push upstream :refs/tags/x.y.z-dev
+git tag x.y.z-dev upstream/release-0.x
+git push upstream x.y.z-dev
+```
+
+Once verified, clean up the `-dev` tag:
+
+```bash
+git tag -d x.y.z-dev
+git push upstream :refs/tags/x.y.z-dev
+```
+
+### 4. Tag and Publish
+
+After the pre-release passes, publish the stable version. The stable tag can
+only be published once — re-tagging is **not allowed**.
+
+```bash
 git pull --rebase upstream release-0.x
 git tag x.y.z upstream/release-0.x
 git push upstream x.y.z
@@ -118,7 +153,15 @@ git checkout release-0.4
 
 # Step 2: Merge stabilization changes via PR (skip if release branch is ready)
 
-# Step 3: Tag and publish
+# Step 3: Pre-release verification
+git pull --rebase upstream release-0.4
+git tag 0.4.0-dev upstream/release-0.4
+git push upstream 0.4.0-dev
+# Wait for workflow to pass, then clean up
+git tag -d 0.4.0-dev
+git push upstream :refs/tags/0.4.0-dev
+
+# Step 4: Tag and publish (stable version, can only be published once)
 git pull --rebase upstream release-0.4
 git tag 0.4.0 upstream/release-0.4
 git push upstream 0.4.0
@@ -136,14 +179,16 @@ for details. Common issues include:
 - **Previous tag not found**: For the first release on a new release branch, the
   workflow automatically detects this and marks all charts as changed.
 
-### Force re-trigger a release
+### Re-trigger a pre-release
 
-If the release workflow fails and you need to re-trigger after fixing the
-issue, delete both the local and remote tag, then re-create and push:
+Only `-dev` pre-release tags can be deleted and re-pushed. To re-trigger:
 
 ```bash
-git tag -d x.y.z
-git push upstream :refs/tags/x.y.z
-git tag x.y.z upstream/release-0.x
-git push upstream x.y.z
+git tag -d x.y.z-dev
+git push upstream :refs/tags/x.y.z-dev
+git tag x.y.z-dev upstream/release-0.x
+git push upstream x.y.z-dev
 ```
+
+**Stable versions (`x.y.z` without suffix) cannot be re-tagged.** If a stable
+release fails, you must publish a new patch version (e.g., `x.y.(z+1)`) instead.

--- a/docs/release.md
+++ b/docs/release.md
@@ -41,16 +41,36 @@ includes merging bug fixes, dependency upgrades, or other stabilization changes
 into `main` via Pull Request. Wait for CI to pass and code review before
 proceeding.
 
-### 2. Pre-release Verification
+### 2. Create Release Branch
 
-Before creating the release branch, push a `-dev` suffixed tag on `main` to
-verify the release workflow. This confirms the code can be released correctly
-without needing a release branch.
+Create a release branch on the upstream repository from the prepared `main`.
+
+**Via GitHub WebUI:** Navigate to the repository page, click "Branch" →
+"New branch", name it `release-0.x` and base it on `main`.
+
+**Via GitHub API / gh CLI:**
 
 ```bash
-git checkout main
-git pull --rebase upstream main
-git tag x.y.z-dev upstream/main
+gh api repos/zncdatadev/commons-operator/git/refs \
+  -f ref=refs/heads/release-0.x \
+  -f sha=$(gh api repos/zncdatadev/commons-operator/git/ref/heads/main --jq .object.sha)
+```
+
+Then sync locally:
+
+```bash
+git fetch upstream
+git checkout release-0.x
+```
+
+### 3. Pre-release Verification
+
+Push a `-dev` suffixed tag on the release branch to verify the release
+workflow. This confirms the code can be released correctly.
+
+```bash
+git pull --rebase upstream release-0.x
+git tag x.y.z-dev upstream/release-0.x
 git push upstream x.y.z-dev
 ```
 
@@ -71,31 +91,8 @@ git tag x.y.z-dev upstream/release-0.x
 git push upstream x.y.z-dev
 ```
 
-Once verified, you can proceed to create the release branch and publish the
-stable version directly. There is no need to clean up the `-dev` tag.
-
-### 3. Create Release Branch
-
-Create a release branch on the upstream repository from the same commit that
-was verified by the pre-release.
-
-**Via GitHub WebUI:** Navigate to the repository page, click "Branch" →
-"New branch", name it `release-0.x` and base it on `main`.
-
-**Via GitHub API / gh CLI:**
-
-```bash
-gh api repos/zncdatadev/commons-operator/git/refs \
-  -f ref=refs/heads/release-0.x \
-  -f sha=$(gh api repos/zncdatadev/commons-operator/git/ref/heads/main --jq .object.sha)
-```
-
-Then sync locally:
-
-```bash
-git fetch upstream
-git checkout release-0.x
-```
+Once verified, you can proceed to publish the stable version directly.
+There is no need to clean up the `-dev` tag.
 
 ### 4. Tag and Publish
 
@@ -139,16 +136,21 @@ Here is an example of releasing version `0.4.0` on the `release-0.4` branch:
 # Step 1: Prepare content on main
 # Merge stabilization changes via PR, wait for CI and review
 
-# Step 2: Pre-release verification
-git checkout main
-git pull --rebase upstream main
-git tag 0.4.0-dev upstream/main
-git push upstream 0.4.0-dev
-# Wait for workflow to pass
+# Step 2: Create release branch on upstream
+# Via WebUI or:
+gh api repos/zncdatadev/commons-operator/git/refs \
+  -f ref=refs/heads/release-0.4 \
+  -f sha=$(gh api repos/zncdatadev/commons-operator/git/ref/heads/main --jq .object.sha)
 
-# Step 3: Create release branch on upstream
+# Sync locally
 git fetch upstream
 git checkout release-0.4
+
+# Step 3: Pre-release verification
+git pull --rebase upstream release-0.4
+git tag 0.4.0-dev upstream/release-0.4
+git push upstream 0.4.0-dev
+# Wait for workflow to pass
 
 # Step 4: Tag and publish (stable version, can only be published once)git pull --rebase upstream release-0.4
 git tag 0.4.0 upstream/release-0.4


### PR DESCRIPTION
Add a comprehensive release guide under `docs/release.md` documenting the standard release process for commons-operator.

The guide covers:
- Release branch strategy (main vs release-x.y)
- Step-by-step release workflow (branch, version bump, PR, tag, publish)
- Files to update for each release (Makefile VERSION, Chart.yaml version/appVersion)
- Automated release workflow job descriptions
- Semantic versioning convention
- Troubleshooting common issues (chart release failures, CRD sync, force re-trigger)
- A complete example for releasing 0.4.0