### PR TITLE
fix(ci): split chart-lint-test into chart-lint-helm and chart-e2e

### DIFF
--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -102,7 +102,7 @@ jobs:
         run: kind load docker-image --name chart-testing quay.io/zncdatadev/commons-operator:$VERSION
 
       - name: Run chart-testing (install)
-        id: ct-test
+
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           ct install --config ./.github/configs/ct-install.yaml

--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -49,7 +49,7 @@ jobs:
         working-directory: deploy/helm
         run: ah lint
 
-  lint-test:
+  chart-lint-helm:
     runs-on: ubuntu-latest
     needs:
       - check-crds-sync
@@ -86,45 +86,39 @@ jobs:
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@v1.14.0
+
+      - name: Setup Go
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: actions/setup-go@v6
         with:
-          cluster_name: kind  # Default cluster name is 'chart-testing'
+          go-version-file: go.mod
+
+      - name: Build image
+        if: steps.list-changed.outputs.changed == 'true'
+        run: make docker-build
 
       - name: Load images to cluster
         if: steps.list-changed.outputs.changed == 'true'
-        run: |
-          make docker-build
-          kind load docker-image quay.io/zncdatadev/commons-operator:$VERSION
-
+        run: kind load docker-image --name chart-testing quay.io/zncdatadev/commons-operator:$VERSION
 
       - name: Run chart-testing (install)
         id: ct-test
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           ct install --config ./.github/configs/ct-install.yaml
-          exit_code=$?
-          # Save success result to github output
-          if [[ $exit_code -eq 0 ]]; then
-            echo "ct_tested=true" >> "$GITHUB_OUTPUT"
-          fi
 
-      - name: Build helm chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          make helm-chart-package
+  chart-e2e:
+    runs-on: ubuntu-latest
+    needs:
+      - check-crds-sync
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
 
-      - name: Run e2e with chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          HELM_DEPENDENCIES=()
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
-          # Install dependencies
-          for dep in "${HELM_DEPENDENCIES[@]}"; do
-            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep oci://quay.io/kubedoopcharts/$dep --version $VERSION
-          done
-
-          # Install packaged operator chart
-          helm install --create-namespace --namespace commons-operators --wait commons-operator ./target/charts/commons-operator-$VERSION.tgz
-
-          # E2E tests
-          make chainsaw
-          ./bin/chainsaw test --config ./test/e2e/chainsaw/.chainsaw.yaml --test-dir ./test/e2e/
+      - name: Run chart-e2e
+        run: make chart-e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,7 @@ jobs:
         run: ah lint
 
 
-  chart-lint-test:
+  chart-lint-helm:
     runs-on: ubuntu-latest
     needs:
       - check-crds-sync
@@ -330,50 +330,45 @@ jobs:
       - name: Create kind cluster
         if: steps.check-changes.outputs.changed == 'true'
         uses: helm/kind-action@v1.14.0
+
+      - name: Setup Go
+        if: steps.check-changes.outputs.changed == 'true'
+        uses: actions/setup-go@v6
         with:
-          cluster_name: kind  # Default cluster name is 'chart-testing'
+          go-version-file: go.mod
+
+      - name: Build image
+        if: steps.check-changes.outputs.changed == 'true'
+        run: make docker-build
 
       - name: Load images to cluster
         if: steps.check-changes.outputs.changed == 'true'
-        run: |
-          make docker-build
-          kind load docker-image quay.io/zncdatadev/commons-operator:$VERSION
+        run: kind load docker-image --name chart-testing quay.io/zncdatadev/commons-operator:$VERSION
 
       - name: Run chart-testing (install)
-        id: ct-test
         if: steps.check-changes.outputs.changed == 'true'
         run: |
           ct install \
             --since "${{ steps.commit-range.outputs.since_commit }}" \
             --target-branch "${{ steps.commit-range.outputs.target_branch }}" \
             --config ./.github/configs/ct-install.yaml
-          exit_code=$?
-          # Save success result to github output
-          if [[ $exit_code -eq 0 ]]; then
-            echo "ct_tested=true" >> "$GITHUB_OUTPUT"
-          fi
 
-      - name: Build helm chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          make helm-chart-package
 
-      - name: Run e2e with chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          HELM_DEPENDENCIES=()
+  chart-e2e:
+    runs-on: ubuntu-latest
+    needs:
+      - check-crds-sync
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
 
-          # Install dependencies
-          for dep in "${HELM_DEPENDENCIES[@]}"; do
-            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep oci://quay.io/kubedoopcharts/$dep --version $VERSION
-          done
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
-          # Install packaged operator chart
-          helm install --create-namespace --namespace commons-operators --wait commons-operator ./target/charts/commons-operator-$VERSION.tgz
-
-          # E2E tests
-          make chainsaw
-          ./bin/chainsaw test --test-dir ./test/e2e/
+      - name: Run chart-e2e
+        run: make chart-e2e
 
 
   release-chart:
@@ -382,7 +377,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - chart-linter-artifacthub
-      - chart-lint-test
+      - chart-lint-helm
+      - chart-e2e
     steps:
       - name: Clone the code
         uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -341,8 +341,8 @@ chainsaw-e2e: ## Run the chainsaw e2e tests
 chart-e2e: setup-chainsaw-cluster chainsaw docker-build helm-chart-package ## Run e2e tests with Helm chart deployment
 	"$(KIND)" --name $(CHAINSAW_CLUSTER) load docker-image "$(IMG)"
 	"$(HELM)" upgrade --install --create-namespace --namespace commons-operators \
-		--kubeconfig $(CHAINSAW_KUBECONFIG) --wait commons-operator \
-		target/charts/commons-operator-$(VERSION).tgz
+		--kubeconfig $(CHAINSAW_KUBECONFIG) --wait $(PROJECT_NAME) \
+		target/charts/$(PROJECT_NAME)-$(VERSION).tgz
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/chainsaw/.chainsaw.yaml --test-dir ./test/e2e/chainsaw/
 
 .PHONY: cleanup-chainsaw-e2e

--- a/Makefile
+++ b/Makefile
@@ -337,6 +337,14 @@ setup-chainsaw-e2e: chainsaw docker-build ## Run the chainsaw setup
 chainsaw-e2e: ## Run the chainsaw e2e tests
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/chainsaw/.chainsaw.yaml --test-dir ./test/e2e/chainsaw/
 
+.PHONY: chart-e2e
+chart-e2e: setup-chainsaw-cluster chainsaw docker-build helm-chart-package ## Run e2e tests with Helm chart deployment
+	"$(KIND)" --name $(CHAINSAW_CLUSTER) load docker-image "$(IMG)"
+	"$(HELM)" upgrade --install --create-namespace --namespace commons-operators \
+		--kubeconfig $(CHAINSAW_KUBECONFIG) --wait commons-operator \
+		target/charts/commons-operator-$(VERSION).tgz
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/chainsaw/.chainsaw.yaml --test-dir ./test/e2e/chainsaw/
+
 .PHONY: cleanup-chainsaw-e2e
 cleanup-chainsaw-e2e: ## Run the chainsaw cleanup
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(MAKE) undeploy


### PR DESCRIPTION
Align with secret-operator CI fixes (#343, #346, #347, #348):

- Split `chart-lint-test`/`lint-test` job into `chart-lint-helm` (ct lint + ct install with kind cluster + image build + load) and `chart-e2e` (make chart-e2e with chainsaw functional tests)
- Add `chart-e2e` Makefile target that builds image, packages chart, loads to chainsaw cluster, installs via helm, and runs chainsaw e2e
- Use default helm/kind-action cluster name (chart-testing) with explicit `--name chart-testing` for kind load docker-image
- Remove inline helm install + chainsaw e2e steps from workflow