### PR TITLE
fix(ci): correct 'make manifests' typo in check-crds-sync error message

### DIFF
--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -30,7 +30,7 @@ jobs:
           # Check if the CRDs are in sync with the manifests
           if ! git diff --exit-code; then
             echo "CRDs are not in sync with the manifests."
-            echo "Please run 'make manifest' to update the CRDs."
+            echo "Please run 'make manifests' to update the CRDs."
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
           # Check if the CRDs are in sync with the manifests
           if ! git diff --exit-code; then
             echo "CRDs are not in sync with the manifests."
-            echo "Please run 'make manifest' to update the CRDs."
+            echo "Please run 'make manifests' to update the CRDs."
             exit 1
           fi
 


### PR DESCRIPTION
## Problem

The error message in check-crds-sync step says `make manifest` (no s) but the actual Makefile target is `make manifests` (with s).

## Changes

Fix the typo in both:
- `.github/workflows/chart-lint-test.yml`
- `.github/workflows/release.yml`