### PR TITLE
fix(e2e): replace bash-specific [[ with POSIX [ for OSTYPE check

### DIFF
--- a/test/e2e/chainsaw/pod-expires/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/pod-expires/chainsaw-test.yaml
@@ -18,9 +18,9 @@ spec:
           value: ($namespace)
         content: |
           # if os is linux, then use date -d, if os is macos, then use date -v
-          if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+          if [ "$OSTYPE" = "linux-gnu" ] || [ "$OSTYPE" = "linux-musl" ]; then
             NOW_AFTER_5s=$(date -d "+5 seconds" -u +"%Y-%m-%dT%H:%M:%SZ")
-          elif [[ "$OSTYPE" == "darwin"* ]]; then
+          elif [ "$OSTYPE" = "darwin" ]; then
             NOW_AFTER_5s=$(date -v+5S -u +"%Y-%m-%dT%H:%M:%SZ")
           fi
 


### PR DESCRIPTION
Chainsaw uses /usr/bin/sh (dash). Replace [[ with [ and == with = for OSTYPE detection.